### PR TITLE
outputFormat osm fix

### DIFF
--- a/src/main/java/com/yellowbkpk/osm/output/OSMOldOutputter.java
+++ b/src/main/java/com/yellowbkpk/osm/output/OSMOldOutputter.java
@@ -139,7 +139,7 @@ public class OSMOldOutputter extends AbstractOutputter {
     
             out.write("  <node ");
             writePrimitveAttrs(out, node);
-            writeAttr(out, "lat", LAT_LON_FORMAT.format(node.getLon()));
+            writeAttr(out, "lat", LAT_LON_FORMAT.format(node.getLat()));
             writeAttr(out, "lon", LAT_LON_FORMAT.format(node.getLon()));
     
             if (node.hasTags()) {


### PR DESCRIPTION
Fixes a typo in --outputFormat osm where the node's lat and lon are both longitude.
